### PR TITLE
Possible approach for requesting cover images

### DIFF
--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -29,6 +29,8 @@ class CampaignController extends Controller
     {
         $campaign = Campaign::findBySlug($slug);
 
+        // dd($campaign->getCoverImage()->getFile()->getUrl());
+
         return view('campaigns.show', ['campaign' => $campaign]);
     }
 }

--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -29,8 +29,6 @@ class CampaignController extends Controller
     {
         $campaign = Campaign::findBySlug($slug);
 
-        // dd($campaign->getCoverImage()->getFile()->getUrl());
-
         return view('campaigns.show', ['campaign' => $campaign]);
     }
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -7,23 +7,17 @@ use Contentful\Delivery\ImageOptions;
  */
 
 /**
- * Get cover image URL for a specified asset by the crop type.
+ * Get image URL for a specified asset by the crop type.
  *
  * @param  \Contentful\Deliver\Asset $asset
  * @param  string $crop
  * @return string
  */
-function get_cover_image_url($asset, $crop = 'large')
+function get_image_url($asset, $crop = 'landscape')
 {
-    $validCrops = ['large', 'square'];
-
-    if (!in_array($crop, $validCrops, true)) {
-        throw new \InvalidArgumentException('The specified cover image type of '.$crop.' is not available.');
-    }
-
     $options = [];
 
-    $options['large'] = (new ImageOptions)
+    $options['landscape'] = (new ImageOptions)
         ->setFormat('jpg')
         ->setWidth(1440)
         ->setHeight(620)
@@ -34,6 +28,10 @@ function get_cover_image_url($asset, $crop = 'large')
         ->setWidth(800)
         ->setHeight(800)
         ->setResizeFit('fill');
+
+    if (! array_key_exists($crop, $options)) {
+        throw new \InvalidArgumentException('The specified cover image type of '.$crop.' is not available.');
+    }
 
     return $asset->getFile()->getUrl($options[$crop]);
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,5 +1,39 @@
 <?php
 
+use Contentful\Delivery\ImageOptions;
+
 /**
  * App helper functions.
  */
+
+/**
+ * Get cover image URL for a specified asset by the crop type.
+ *
+ * @param  \Contentful\Deliver\Asset $asset
+ * @param  string $crop
+ * @return string
+ */
+function get_cover_image_url($asset, $crop = 'large')
+{
+    $validCrops = ['large', 'square'];
+
+    if (!in_array($crop, $validCrops, true)) {
+        throw new \InvalidArgumentException('The specified cover image type of '.$crop.' is not available.');
+    }
+
+    $options = [];
+
+    $options['large'] = (new ImageOptions)
+        ->setFormat('jpg')
+        ->setWidth(1440)
+        ->setHeight(620)
+        ->setResizeFit('fill');
+
+    $options['square'] = (new ImageOptions)
+        ->setFormat('jpg')
+        ->setWidth(800)
+        ->setHeight(800)
+        ->setResizeFit('fill');
+
+    return $asset->getFile()->getUrl($options[$crop]);
+}

--- a/resources/views/campaigns/index.blade.php
+++ b/resources/views/campaigns/index.blade.php
@@ -5,10 +5,8 @@
     <ul>
         @foreach($campaigns as $campaign)
             <li>
-                <p>{{ $campaign->getTitle() }}</p>
+                <h2><a href="{{ url('campaigns/'.$campaign->getSlug()) }}">{{ $campaign->getTitle() }}<a/></h2>
                 <p>{{ $campaign->getCallToAction() }}</p>
-                <p>{{ $campaign->getStatus() }}</p>
-                <p>{{ $campaign->getSlug() }}</p>
             </li>
         @endforeach
     </ul>

--- a/resources/views/campaigns/show.blade.php
+++ b/resources/views/campaigns/show.blade.php
@@ -9,5 +9,5 @@
 
     <p>{{ $campaign->getSolutionFact() }}</p>
 
-    <img src="{{ get_cover_image_url($campaign->getCoverImage(), 'large') }}">
+    <img alt="{{ $campaign->getCoverImage()->getTitle() }}" src="{{ get_image_url($campaign->getCoverImage(), 'landscape') }}">
 @endsection

--- a/resources/views/campaigns/show.blade.php
+++ b/resources/views/campaigns/show.blade.php
@@ -8,4 +8,6 @@
     <p><i>{{ $campaign->getProblemFact()->getSource() }}</i></p>
 
     <p>{{ $campaign->getSolutionFact() }}</p>
+
+    <img src="{{ get_cover_image_url($campaign->getCoverImage(), 'large') }}">
 @endsection

--- a/tests/units/HelpersTest.php
+++ b/tests/units/HelpersTest.php
@@ -1,0 +1,15 @@
+<?php
+
+class HelpersTest extends TestCase
+{
+    /** @test */
+    public function can_get_a_campaign_cover_image_url()
+    {
+        // @TODO: Use a mock!
+        $asset = app('contentful.delivery')->getAsset('13XDOJIsxuSegEMUuqmwWc');
+
+        $url = get_image_url($asset, 'landscape');
+
+        $this->assertEquals('//images.contentful.com/2nh7n4rfkw4q/13XDOJIsxuSegEMUuqmwWc/4ce66876aeaa784d62454a29bc776cf9/sample-cover-image-01.jpg?w=1440&h=620&fm=jpg&fit=fill', $url);
+    }
+}


### PR DESCRIPTION
This PR provides a possibly solution that might provide a path to how we handle retrieving different cropped sizes of specifically the Cover Images for a Campaign, but it could very likely be generalized to apply to other images retrieved from Contentful.

This is definitely up for discussion, but I wanted to experiment with an approach.

![image](https://cloud.githubusercontent.com/assets/105849/21021058/f9975732-bd44-11e6-8b62-18538e87f008.png)

---
@DFurnes @deadlybutter 

cc: @angaither 