### PR TITLE
Simple approach to viewing an inactive vs active version of a campaign.

### DIFF
--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -32,6 +32,10 @@ class CampaignController extends Controller
 
         $campaign = Campaign::findBySlug($slug);
 
-        return view('campaigns.show', ['campaign' => $campaign]);
+        if (! Campaign::isActive($campaign)) {
+            return view('campaigns.inactive.show', ['campaign' => $campaign]);
+        }
+
+        return view('campaigns.active.show', ['campaign' => $campaign]);
     }
 }

--- a/app/Models/Campaign.php
+++ b/app/Models/Campaign.php
@@ -57,4 +57,15 @@ class Campaign
     {
         return app('contentful.delivery');
     }
+
+    /**
+     * Determine if the specified campaign is active.
+     *
+     * @param  \Contentful\Delivery\DynamicEntry  $campaign
+     * @return boolean
+     */
+    public static function isActive($campaign)
+    {
+        return $campaign->getActive();
+    }
 }

--- a/resources/views/campaigns/active/show.blade.php
+++ b/resources/views/campaigns/active/show.blade.php
@@ -1,6 +1,7 @@
 @extends('layouts.master')
 
 @section('content')
+    <em>This campaign is active!</em>
     <h1>{{ $campaign->getTitle() }}</h1>
     <h2>{{ $campaign->getCallToAction() }}</h2>
 

--- a/resources/views/campaigns/inactive/show.blade.php
+++ b/resources/views/campaigns/inactive/show.blade.php
@@ -1,0 +1,14 @@
+@extends('layouts.master')
+
+@section('content')
+    <em>This campaign is inactive!</em>
+    <h1>{{ $campaign->getTitle() }}</h1>
+    <h2>{{ $campaign->getCallToAction() }}</h2>
+
+    <p>{{ $campaign->getProblemFact()->getContent() }}</p>
+    <p><i>{{ $campaign->getProblemFact()->getSource() }}</i></p>
+
+    <p>{{ $campaign->getSolutionFact() }}</p>
+
+    <img alt="{{ $campaign->getCoverImage()->getTitle() }}" src="{{ get_image_url($campaign->getCoverImage(), 'landscape') }}">
+@endsection


### PR DESCRIPTION
This PR provides a quick solution to viewing a Campaign when it is _active_ or _inactive_ (open/closed). This only addresses an aspect of campaign status... there is currently a bigger question on how **slugs** will be handled, etc. However, the decisions behind the larger questions will have to wait until we know more about what changes Campaigns 2.0 will bring!

In an upcoming PR we are planning to place a wrapper around the data received from Contentful to transform it a bit and make it easier to use in templating. Ideally then we'll be able to use:

```php
if (! $campagin->isActive()) { ... }
```
instead of the current implementation in this PR.

---
@DFurnes @deadlybutter 

cc: @angaither 