### PR TITLE
Use localized images & add query string for locale.

### DIFF
--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -44,9 +44,6 @@ class CampaignController extends Controller
      */
     public function show($slug)
     {
-        // @NOTE: Uncomment this line to demo globalization!
-//        app()->setLocale('es-MX');
-
         $campaign = $this->campaignRepository->findBySlug($slug);
 
         if (! $campaign->isActive()) {

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -30,6 +30,7 @@ class Kernel extends HttpKernel
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             \App\Http\Middleware\VerifyCsrfToken::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
+            \App\Http\Middleware\SetLocale::class,
         ],
 
         'api' => [

--- a/app/Http/Middleware/SetLocale.php
+++ b/app/Http/Middleware/SetLocale.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+
+class SetLocale
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @param  string|null  $guard
+     * @return mixed
+     */
+    public function handle($request, Closure $next, $guard = null)
+    {
+        $locale = $request->query('locale');
+
+        if ($locale) {
+            app()->setLocale($locale);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,5 +1,6 @@
 <?php
 
+use Contentful\Delivery\Asset;
 use Contentful\Delivery\ImageOptions;
 use Illuminate\Support\HtmlString;
 
@@ -24,11 +25,11 @@ function markdown($source)
 /**
  * Get image URL for a specified asset by the crop type.
  *
- * @param  \Contentful\Deliver\Asset $asset
+ * @param Asset $asset
  * @param  string $crop
  * @return string
  */
-function get_image_url($asset, $crop = 'landscape')
+function get_image_url(Asset $asset, $crop = 'landscape')
 {
     $options = [];
 
@@ -48,5 +49,7 @@ function get_image_url($asset, $crop = 'landscape')
         throw new \InvalidArgumentException('The specified cover image type of '.$crop.' is not available.');
     }
 
-    return $asset->getFile()->getUrl($options[$crop]);
+    $locale = app()->getLocale();
+
+    return $asset->getFile($locale)->getUrl($options[$crop]);
 }


### PR DESCRIPTION
This PR adds support for pulling localized images to the `get_image_url` helper method, and adds a middleware to set the application's locale by using the `?locale=` query string. 🌐